### PR TITLE
feat: add /batch-check-translations endpoint

### DIFF
--- a/src/class-rest-api.php
+++ b/src/class-rest-api.php
@@ -120,12 +120,6 @@ class REST_API {
             ],
         ] );
 
-        // Public download endpoint for translation packages.
-        register_rest_route( $this->namespace, '/download/(?P<textdomain>[a-z0-9_-]+)/(?P<version>[^/]+)/(?P<locale>[a-z]{2,3}(?:_[A-Z]{2})?)', [
-            'methods'             => \WP_REST_Server::READABLE,
-            'callback'            => [ $this, 'download_package' ],
-            'permission_callback' => '__return_true',
-        ] );
     }
 
     /**
@@ -266,7 +260,7 @@ class REST_API {
                 if ( $job && in_array( $job['status'], [ 'processing', 'pending' ], true ) ) {
                     $results[ $textdomain ][ $locale ] = [
                         'status'         => $job['status'],
-                        'queue_position' => $queue->get_queue_position( $job['id'] ),
+                        'queue_position' => $queue->get_queue_position( (int) $job['id'] ),
                     ];
                     continue;
                 }


### PR DESCRIPTION
## Summary

New `POST /batch-check-translations` endpoint that accepts up to 100 `{textdomain, version}` pairs and a locales array, returns per-textdomain results, and auto-queues missing locales — all in **one round trip**. Replaces `N` calls to `/check-translations` followed by `N` calls to `/request-translation`.

Used by the client plugin's chunked refresh, which now completes a 50-plugin scan in **~1.3s** (was 64.7s using the per-plugin endpoints).

## Why

The client plugin was making 3 sync HTTP calls per installed plugin during translation refresh: one to `api.wordpress.org`, one to `/check-translations`, and one to `/request-translation`. On a site with 50 plugins this took 64.7 seconds — well over PHP's default `max_execution_time` of 30s. The cron handler would die mid-loop, leaving the cache empty and the stats wrong.

This endpoint collapses the per-plugin loop on the server side, returning everything the client needs in a single response.

## API

Request:
```json
{
  "plugins":    [{"textdomain": "akismet", "version": "5.6"}, ...],
  "locales":    ["es_ES", "fr_FR"],
  "auto_queue": true
}
```

Response:
```json
{
  "results": {
    "akismet": { "es_ES": { "package_url": "...", "updated": "..." } }
  },
  "queued":       [{ "textdomain": "my-plugin", "locale": "es_ES" }],
  "queue_length": 12
}
```

## Other changes

- Resolved a pre-existing unresolved git merge conflict in `class-rest-api.php` (`<<<<<<< HEAD ... 22ab78e (Add batch method)`).
- Removed a phantom `/download` route that referenced a non-existent `download_package` method.

## Test plan

Verified end-to-end against the live dev instance at `translate.ultimatemultisite.com`:

```
$ curl -X POST .../batch-check-translations -d '{"plugins":[...],"locales":["es_ES"]}'
{"results":{...},"queued":[44 entries],"queue_length":44}
```

Client plugin's chunked refresh against this endpoint:
- 50 plugins, 1 locale → **1.29s total** across 2 chunks of 25
- Server queue accepted all 44 generation requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Removed the REST endpoint for downloading translation packages. Applications relying on this endpoint will need to use alternative methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->