### PR TITLE
GH#7: fix locales cap and format validation in batch-check-translations

### DIFF
--- a/src/class-rest-api.php
+++ b/src/class-rest-api.php
@@ -226,6 +226,10 @@ class REST_API {
             return new \WP_Error( 'invalid_locales', 'locales must be a non-empty array', [ 'status' => 400 ] );
         }
 
+        if ( count( $locales ) > 20 ) {
+            return new \WP_Error( 'too_many_locales', 'maximum 20 locales per batch', [ 'status' => 400 ] );
+        }
+
         $queue   = Translation_Queue::instance();
         $results = [];
         $queued  = [];
@@ -246,6 +250,11 @@ class REST_API {
 
             foreach ( $locales as $locale ) {
                 $locale = sanitize_text_field( (string) $locale );
+
+                if ( ! preg_match( '/^[a-z]{2,3}(_[A-Z]{2,3})?$/', $locale ) ) {
+                    continue;
+                }
+
                 $job    = $queue->get_job( $textdomain, $version, $locale );
 
                 if ( $job && $job['status'] === 'completed' ) {


### PR DESCRIPTION
## Summary

Address two unaddressed CodeRabbit review findings from PR #6 in `src/class-rest-api.php`.

### Changes

**1. Locales array cap (Major)**

The `plugins` array was already capped at 100 entries, but `locales` had no limit. An attacker could send 100 plugins × unlimited locales = potentially tens of thousands of DB operations per request (DoS vector). Cap added at 20 locales per batch — sufficient for any realistic multi-locale deployment.

**2. Locale format validation (Nitpick)**

The `textdomain` field was already validated against `/^[a-z0-9_-]{1,80}$/i`, but `locale` only ran through `sanitize_text_field()`. Invalid locale strings (e.g. path traversal attempts, SQL fragments post-sanitisation) would be silently passed to `get_job()`. Now invalid locale entries are skipped rather than propagated.

## Files changed

- EDIT: `src/class-rest-api.php` — locales count cap + locale regex validation

## Testing

Self-assessed (Low risk — input validation only, no logic change):
- PHP syntax valid (no parse errors)
- Logic: `en_US`, `fr_FR`, `pt_BR`, `fy` all match `/^[a-z]{2,3}(_[A-Z]{2,3})?$/`; invalid strings like `../../etc` do not match and are skipped
- Count guard mirrors existing `plugins` count guard pattern

Resolves #7


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.5 plugin for [OpenCode](https://opencode.ai) v1.3.16 with claude-sonnet-4-6 spent 2m and 5,274 tokens on this as a headless worker.