### PR TITLE
chore: initialize aidevops planning infrastructure

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,11 @@
+# ultimate-ai-translation-server — Agent Instructions
+
+## Project-Specific Rules
+
+<!-- Add project-specific conventions, patterns, and constraints here. -->
+
+## Security
+
+- Never commit secrets, API keys, or credentials
+- Use environment variables or `~/.config/aidevops/credentials.sh` for sensitive values
+- Review all AI-generated code before merging

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,24 @@
+# TODO
+
+Project task tracking with time estimates, dependencies, and TOON-enhanced parsing.
+
+## Format
+
+Format: `- [ ] tNNN Description @owner #tag ~estimate risk:level logged:date`
+
+## In Progress
+
+<!-- Tasks currently being worked on -->
+
+## Backlog
+
+<!-- Prioritized list of upcoming tasks -->
+
+## Completed
+
+<!-- Tasks that have been completed -->
+
+---
+
+*Format: `- [ ] Task description @owner #tag ~estimate`*
+*Time tracking: `started:`, `completed:`, `actual:`*

--- a/todo/PLANS.md
+++ b/todo/PLANS.md
@@ -1,0 +1,15 @@
+# Execution Plans
+
+Complex, multi-session work that requires detailed planning.
+
+## Active Plans
+
+<!-- Plans currently in progress -->
+
+## Completed Plans
+
+<!-- Archived completed plans -->
+
+---
+
+*See `.agents/workflows/plans.md` for planning workflow*


### PR DESCRIPTION
## Summary

- Add TODO.md for task tracking
- Add AGENTS.md for AI assistant context
- Add .agents/AGENTS.md for project-specific agent instructions
- Add todo/PLANS.md and todo/tasks/ for execution planning

No existing files were overwritten. Only new scaffolding files added.

---
Batch-initialized by aidevops v3.8.63