### PR TITLE
fix: schedule recurring WP-Cron event for queue processing

### DIFF
--- a/gratis-ai-translations-server.php
+++ b/gratis-ai-translations-server.php
@@ -49,15 +49,6 @@ spl_autoload_register( function ( $class ) {
     }
 } );
 
-// Register custom cron interval early so it's available during activation and runtime.
-add_filter( 'cron_schedules', function ( array $schedules ): array {
-    $schedules['gratis_ai_ts_every_five_minutes'] = [
-        'interval' => 5 * MINUTE_IN_SECONDS,
-        'display'  => esc_html__( 'Every Five Minutes', 'gratis-ai-translations-server' ),
-    ];
-    return $schedules;
-} );
-
 /**
  * Initialize the plugin.
  *
@@ -119,13 +110,8 @@ function activate(): void {
     require_once ABSPATH . 'wp-admin/includes/upgrade.php';
     dbDelta( $sql );
 
-    if ( ! wp_next_scheduled( 'gratis_ai_ts_cleanup_old_jobs' ) ) {
-        wp_schedule_event( time(), 'daily', 'gratis_ai_ts_cleanup_old_jobs' );
-    }
-
-    if ( ! wp_next_scheduled( 'gratis_ai_ts_process_queue' ) ) {
-        wp_schedule_event( time(), 'gratis_ai_ts_every_five_minutes', 'gratis_ai_ts_process_queue' );
-    }
+    // Recurring Action Scheduler events are registered in Translation_Queue::init()
+    // which runs on plugins_loaded — after AS is fully initialized.
 
     add_site_option( 'gratis_ai_ts_max_concurrent_jobs', 3 );
     add_site_option( 'gratis_ai_ts_batch_size', 50 );
@@ -139,8 +125,9 @@ register_activation_hook( GRATIS_AI_TS_FILE, __NAMESPACE__ . '\\activate' );
  * @return void
  */
 function deactivate(): void {
-    wp_clear_scheduled_hook( 'gratis_ai_ts_cleanup_old_jobs' );
-    wp_clear_scheduled_hook( 'gratis_ai_ts_process_queue' );
+    as_unschedule_all_actions( 'gratis_ai_ts_cleanup_old_jobs', [], 'gratis_ai_ts' );
+    as_unschedule_all_actions( 'gratis_ai_ts_process_queue', [], 'gratis_ai_ts' );
+    as_unschedule_all_actions( 'gratis_ai_ts_generate_translation', [], 'gratis_ai_ts' );
 }
 
 register_deactivation_hook( GRATIS_AI_TS_FILE, __NAMESPACE__ . '\\deactivate' );

--- a/gratis-ai-translations-server.php
+++ b/gratis-ai-translations-server.php
@@ -49,6 +49,15 @@ spl_autoload_register( function ( $class ) {
     }
 } );
 
+// Register custom cron interval early so it's available during activation and runtime.
+add_filter( 'cron_schedules', function ( array $schedules ): array {
+    $schedules['gratis_ai_ts_every_five_minutes'] = [
+        'interval' => 5 * MINUTE_IN_SECONDS,
+        'display'  => esc_html__( 'Every Five Minutes', 'gratis-ai-translations-server' ),
+    ];
+    return $schedules;
+} );
+
 /**
  * Initialize the plugin.
  *
@@ -112,6 +121,10 @@ function activate(): void {
 
     if ( ! wp_next_scheduled( 'gratis_ai_ts_cleanup_old_jobs' ) ) {
         wp_schedule_event( time(), 'daily', 'gratis_ai_ts_cleanup_old_jobs' );
+    }
+
+    if ( ! wp_next_scheduled( 'gratis_ai_ts_process_queue' ) ) {
+        wp_schedule_event( time(), 'gratis_ai_ts_every_five_minutes', 'gratis_ai_ts_process_queue' );
     }
 
     add_site_option( 'gratis_ai_ts_max_concurrent_jobs', 3 );

--- a/src/class-translation-queue.php
+++ b/src/class-translation-queue.php
@@ -64,9 +64,13 @@ class Translation_Queue {
      * @return void
      */
     public function init(): void {
-        // Queue processing is triggered on-demand via do_action() or WP-CLI.
         add_action( 'gratis_ai_ts_process_queue', [ $this, 'process_queue' ] );
         add_action( 'gratis_ai_ts_cleanup_old_jobs', [ $this, 'cleanup_old_jobs' ] );
+
+        // Self-heal: re-schedule if the recurring event was lost (e.g. database restore).
+        if ( ! wp_next_scheduled( 'gratis_ai_ts_process_queue' ) ) {
+            wp_schedule_event( time(), 'gratis_ai_ts_every_five_minutes', 'gratis_ai_ts_process_queue' );
+        }
     }
 
     /**
@@ -120,9 +124,11 @@ class Translation_Queue {
 
         $job_id = $wpdb->insert_id;
 
-        // Trigger immediate processing if queue is empty.
-        if ($this->get_pending_count() === 1) {
-            do_action('gratis_ai_ts_process_queue');
+        // Schedule immediate processing so the new job doesn't wait for the next
+        // 5-minute cron tick. wp_schedule_single_event is a no-op if an identical
+        // event already exists at the same timestamp.
+        if ( ! wp_next_scheduled( 'gratis_ai_ts_process_queue' ) || $this->get_pending_count() <= $this->get_available_slots() ) {
+            wp_schedule_single_event( time(), 'gratis_ai_ts_process_queue' );
         }
 
         return $job_id;
@@ -230,6 +236,19 @@ class Translation_Queue {
     }
 
     /**
+     * Get available processing slots.
+     *
+     * @since 1.1.1
+     * @return int Number of available slots.
+     */
+    public function get_available_slots(): int {
+        $max_concurrent = (int) get_site_option( 'gratis_ai_ts_max_concurrent_jobs', 3 );
+        $processing     = $this->get_processing_count();
+
+        return max( 0, $max_concurrent - $processing );
+    }
+
+    /**
      * Get processing jobs count.
      *
      * @since 1.0.0
@@ -320,16 +339,11 @@ class Translation_Queue {
      * @return void
      */
     public function process_queue(): void {
-        $max_concurrent = (int) get_site_option('gratis_ai_ts_max_concurrent_jobs', 3);
+        $slots_available = $this->get_available_slots();
 
-        // Check if we can process more jobs.
-        $processing = $this->get_processing_count();
-
-        if ($processing >= $max_concurrent) {
+        if ( $slots_available <= 0 ) {
             return;
         }
-
-        $slots_available = $max_concurrent - $processing;
 
         for ($i = 0; $i < $slots_available; $i++) {
             $job = $this->get_next_pending_job();

--- a/src/class-translation-queue.php
+++ b/src/class-translation-queue.php
@@ -66,11 +66,42 @@ class Translation_Queue {
     public function init(): void {
         add_action( 'gratis_ai_ts_process_queue', [ $this, 'process_queue' ] );
         add_action( 'gratis_ai_ts_cleanup_old_jobs', [ $this, 'cleanup_old_jobs' ] );
+        add_action( 'gratis_ai_ts_generate_translation', [ $this, 'handle_generate_translation' ] );
 
-        // Self-heal: re-schedule if the recurring event was lost (e.g. database restore).
-        if ( ! wp_next_scheduled( 'gratis_ai_ts_process_queue' ) ) {
-            wp_schedule_event( time(), 'gratis_ai_ts_every_five_minutes', 'gratis_ai_ts_process_queue' );
+        // Schedule recurring actions after Action Scheduler's DB store initializes
+        // (AS registers its store on the 'init' hook at priority 1).
+        add_action( 'init', [ $this, 'ensure_scheduled_actions' ], 10 );
+    }
+
+    /**
+     * Ensure recurring Action Scheduler actions exist.
+     *
+     * Hooked to 'init' at priority 10 (after AS's DB store at priority 1)
+     * so the store is ready when we schedule. Runs on every page load to
+     * self-heal after activation, database restores, or accidental deletion.
+     *
+     * @since 1.1.1
+     * @return void
+     */
+    public function ensure_scheduled_actions(): void {
+        if ( false === as_next_scheduled_action( 'gratis_ai_ts_process_queue', [], 'gratis_ai_ts' ) ) {
+            as_schedule_recurring_action( time(), 5 * MINUTE_IN_SECONDS, 'gratis_ai_ts_process_queue', [], 'gratis_ai_ts' );
         }
+
+        if ( false === as_next_scheduled_action( 'gratis_ai_ts_cleanup_old_jobs', [], 'gratis_ai_ts' ) ) {
+            as_schedule_recurring_action( time(), DAY_IN_SECONDS, 'gratis_ai_ts_cleanup_old_jobs', [], 'gratis_ai_ts' );
+        }
+    }
+
+    /**
+     * Handle the async generate_translation action dispatched by Action Scheduler.
+     *
+     * @since 1.1.1
+     * @param int $job_id Job ID.
+     * @return void
+     */
+    public function handle_generate_translation( int $job_id ): void {
+        Translation_Generator::instance()->generate_translation( $job_id );
     }
 
     /**
@@ -124,11 +155,10 @@ class Translation_Queue {
 
         $job_id = $wpdb->insert_id;
 
-        // Schedule immediate processing so the new job doesn't wait for the next
-        // 5-minute cron tick. wp_schedule_single_event is a no-op if an identical
-        // event already exists at the same timestamp.
-        if ( ! wp_next_scheduled( 'gratis_ai_ts_process_queue' ) || $this->get_pending_count() <= $this->get_available_slots() ) {
-            wp_schedule_single_event( time(), 'gratis_ai_ts_process_queue' );
+        // Schedule immediate queue processing so the new job doesn't wait for
+        // the next 5-minute recurring tick.
+        if ( false === as_next_scheduled_action( 'gratis_ai_ts_process_queue', [], 'gratis_ai_ts' ) ) {
+            as_schedule_single_action( time(), 'gratis_ai_ts_process_queue', [], 'gratis_ai_ts' );
         }
 
         return $job_id;
@@ -368,20 +398,12 @@ class Translation_Queue {
      * @return void
      */
     private function process_job(int $job_id): void {
-        $generator = Translation_Generator::instance();
-
-        // Use Action Scheduler if available for async processing.
-        if (function_exists('as_schedule_single_action')) {
-            as_schedule_single_action(
-                time(),
-                'gratis_ai_ts_generate_translation',
-                ['job_id' => $job_id],
-                'gratis_ai_ts'
-            );
-        } else {
-            // Process synchronously.
-            $generator->generate_translation($job_id);
-        }
+        as_schedule_single_action(
+            time(),
+            'gratis_ai_ts_generate_translation',
+            [ 'job_id' => $job_id ],
+            'gratis_ai_ts'
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary

- Fixes queued translation jobs never being processed because `gratis_ai_ts_process_queue` was never scheduled as a recurring WP-Cron event — only cleanup was scheduled
- Registers a custom 5-minute cron interval and schedules recurring queue processing on plugin activation
- Adds a self-healing check in `Translation_Queue::init()` to re-schedule the event if lost (e.g. database restore)
- Replaces the synchronous `do_action()` in `add_job()` (which only fired when pending count was exactly 1) with `wp_schedule_single_event()` for immediate async processing regardless of queue depth
- Extracts `get_available_slots()` to deduplicate slot calculation between `add_job()` and `process_queue()`

## Testing

```bash
wp plugin deactivate ultimate-ai-translation-server
wp plugin activate ultimate-ai-translation-server
wp cron event list | grep gratis_ai_ts
# gratis_ai_ts_process_queue     ... 5 minutes
# gratis_ai_ts_cleanup_old_jobs  ... 1 day
wp cron schedule list | grep gratis
# gratis_ai_ts_every_five_minutes  Every Five Minutes  300
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation job scheduling reliability by migrating to Action Scheduler for more consistent background job processing.
  * Enhanced concurrency control to better manage simultaneous translation job execution.

* **Improvements**
  * Optimized automatic job scheduling and cleanup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->