### PR TITLE
Fix server CLI status fatal

### DIFF
--- a/src/class-translation-queue.php
+++ b/src/class-translation-queue.php
@@ -316,6 +316,30 @@ class Translation_Queue {
     }
 
     /**
+     * Get completed jobs count for the current site day.
+     *
+     * @since 1.1.1
+     * @return int Count.
+     */
+    public function get_completed_count_today(): int {
+        global $wpdb;
+
+        $start = new \DateTimeImmutable('today', wp_timezone());
+        $end   = $start->modify('+1 day');
+
+        return (int) $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT COUNT(*) FROM {$this->table_name}
+                WHERE status = 'completed'
+                AND completed_at >= %s
+                AND completed_at < %s",
+                $start->format('Y-m-d H:i:s'),
+                $end->format('Y-m-d H:i:s')
+            )
+        );
+    }
+
+    /**
      * Get count by status.
      *
      * @since 1.1.0


### PR DESCRIPTION
## Summary
- Add `Translation_Queue::get_completed_count_today()` used by `wp gratis-ai-server status`
- Count completed jobs within the current WordPress site timezone day
- Prevent the server status command from fataling before E2E checks can proceed

## Verification
- `php -l src/class-translation-queue.php`
- `wp gratis-ai-server status`
- `wp gratis-ai-server list --limit=5`
- `wp gratis-ai-server process --limit=1`

## Context
Discovered during local end-to-end testing of the client/server translation flow. The fatal was caused by `src/class-cli.php` calling a queue method that did not exist.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.0 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 17h 15m and 208,512 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying how many translation jobs were completed today, based on the site’s local day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->