### PR TITLE
fix: harden translation queue processing

### DIFF
--- a/gratis-ai-translations-server.php
+++ b/gratis-ai-translations-server.php
@@ -24,6 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'GRATIS_AI_TS_VERSION', '1.1.0' );
+define( 'GRATIS_AI_TS_SCHEMA_VERSION', '1.1.1' );
 define( 'GRATIS_AI_TS_FILE', __FILE__ );
 define( 'GRATIS_AI_TS_DIR', plugin_dir_path( __FILE__ ) );
 
@@ -64,6 +65,8 @@ function init(): void {
         return;
     }
 
+    maybe_update_schema();
+
     REST_API::instance()->init();
     Translation_Queue::instance()->init();
     Translation_Generator::instance()->init();
@@ -86,17 +89,37 @@ function init(): void {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\init', 20 );
 
 /**
- * Activation hook — create the jobs table and set defaults.
+ * Ensure the jobs table matches the current plugin schema.
+ *
+ * The table predates several columns used by the current queue code. Running
+ * dbDelta behind a schema-version option self-heals production installs after
+ * code deploys and avoids relying on activation hooks for upgrades.
  *
  * @return void
  */
-function activate(): void {
+function maybe_update_schema(): void {
+    $installed = (string) get_site_option( 'gratis_ai_ts_schema_version', '' );
+
+    if ( GRATIS_AI_TS_SCHEMA_VERSION === $installed ) {
+        return;
+    }
+
+    install_schema();
+    update_site_option( 'gratis_ai_ts_schema_version', GRATIS_AI_TS_SCHEMA_VERSION );
+}
+
+/**
+ * Create or update the translation jobs table.
+ *
+ * @return void
+ */
+function install_schema(): void {
     global $wpdb;
 
     $table   = $wpdb->base_prefix . 'gratis_ai_translation_jobs';
     $charset = $wpdb->get_charset_collate();
 
-    $sql = "CREATE TABLE IF NOT EXISTS {$table} (
+    $sql = "CREATE TABLE {$table} (
         id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
         textdomain varchar(100) NOT NULL,
         version varchar(20) NOT NULL,
@@ -122,6 +145,16 @@ function activate(): void {
 
     require_once ABSPATH . 'wp-admin/includes/upgrade.php';
     dbDelta( $sql );
+}
+
+/**
+ * Activation hook — create the jobs table and set defaults.
+ *
+ * @return void
+ */
+function activate(): void {
+    install_schema();
+    update_site_option( 'gratis_ai_ts_schema_version', GRATIS_AI_TS_SCHEMA_VERSION );
 
     // Recurring Action Scheduler events are registered in Translation_Queue::init()
     // which runs on plugins_loaded — after AS is fully initialized.

--- a/src/class-rest-api.php
+++ b/src/class-rest-api.php
@@ -199,9 +199,11 @@ class REST_API {
                     'updated'     => $job['completed_at'],
                 ];
             } else {
-                // Create as 'requested' unless auto_approve is true.
-                $status = $auto_approve ? 'pending' : 'requested';
+                // Create/reset as requested, then approve when requested by caller.
                 $job_id = $queue->add_job( $textdomain, $version, $locale, $priority, 'api', $site_url );
+                if ( $auto_approve && $job_id ) {
+                    $queue->approve_job( (int) $job_id );
+                }
                 $queued[] = $locale;
 
                 // Trigger processing immediately if auto-approved.
@@ -323,6 +325,16 @@ class REST_API {
                 }
 
                 if ( $job && $job['status'] === 'requested' ) {
+                    if ( $auto_approve ) {
+                        $queue->approve_job( (int) $job['id'] );
+                        $approved[] = [ 'textdomain' => $textdomain, 'locale' => $locale ];
+                        $results[ $textdomain ][ $locale ] = [
+                            'status'         => 'pending',
+                            'queue_position' => $queue->get_queue_position( (int) $job['id'] ),
+                        ];
+                        continue;
+                    }
+
                     $results[ $textdomain ][ $locale ] = [
                         'status'         => 'requested',
                         'awaiting_approval' => true,
@@ -330,9 +342,14 @@ class REST_API {
                     continue;
                 }
 
-                // Create as requested (not auto-approved).
+                // Create/reset as requested, then approve when requested by caller.
                 $job_id = $queue->add_job( $textdomain, $version, $locale, 5, 'api', $site_url, $plugin_source );
-                $requested[] = [ 'textdomain' => $textdomain, 'locale' => $locale ];
+                if ( $auto_approve && $job_id ) {
+                    $queue->approve_job( (int) $job_id );
+                    $approved[] = [ 'textdomain' => $textdomain, 'locale' => $locale ];
+                } else {
+                    $requested[] = [ 'textdomain' => $textdomain, 'locale' => $locale ];
+                }
             }
         }
 

--- a/src/class-translation-generator.php
+++ b/src/class-translation-generator.php
@@ -108,12 +108,21 @@ class Translation_Generator {
             // import — without this, Automation::on_originals_imported() fires
             // and schedules AI translations for ALL configured locales.
             $this->suppress_automation_hooks();
-            $import_ok = $this->import_from_wporg_glotpress( $project, $translation_set, $job['textdomain'], $job['locale'] );
-            $this->restore_automation_hooks();
+            try {
+                $import_ok = $this->import_from_wporg_glotpress( $project, $translation_set, $job['textdomain'], $job['locale'] );
+            } finally {
+                $this->restore_automation_hooks();
+            }
 
             if ( ! $import_ok ) {
                 // Fallback: try the old POT + human import path for non-wp.org plugins.
-                $pot_imported = $this->import_pot_file( $project, $job['textdomain'], $job['version'] );
+                $this->suppress_automation_hooks();
+                try {
+                    $pot_imported = $this->import_pot_file( $project, $job['textdomain'], $job['version'] );
+                } finally {
+                    $this->restore_automation_hooks();
+                }
+
                 if ( ! $pot_imported ) {
                     $queue->update_job_status( $job_id, 'failed', [
                         'error_message' => 'Failed to import source strings',
@@ -218,6 +227,14 @@ class Translation_Generator {
     private ?array $suppressed_automation_callback = null;
 
     /**
+     * Stored Automation callback priority for hook restoration.
+     *
+     * @since 1.2.0
+     * @var int
+     */
+    private int $suppressed_automation_priority = 10;
+
+    /**
      * Suppress gp-openai-translate's Automation hook on gp_originals_imported.
      *
      * Prevents the Automation class from scheduling AI translations for ALL
@@ -242,6 +259,7 @@ class Translation_Generator {
                     && $callback['function'][0] instanceof \Meloniq\GpOpenaiTranslate\Automation
                 ) {
                     $this->suppressed_automation_callback = $callback['function'];
+                    $this->suppressed_automation_priority = (int) $priority;
                     remove_action( 'gp_originals_imported', $callback['function'], $priority );
                     return;
                 }
@@ -257,8 +275,9 @@ class Translation_Generator {
      */
     private function restore_automation_hooks(): void {
         if ( $this->suppressed_automation_callback ) {
-            add_action( 'gp_originals_imported', $this->suppressed_automation_callback, 10, 5 );
+            add_action( 'gp_originals_imported', $this->suppressed_automation_callback, $this->suppressed_automation_priority, 5 );
             $this->suppressed_automation_callback = null;
+            $this->suppressed_automation_priority = 10;
         }
     }
 

--- a/src/class-translation-queue.php
+++ b/src/class-translation-queue.php
@@ -35,6 +35,14 @@ class Translation_Queue {
     private string $table_name;
 
     /**
+     * Maximum age for a processing job before the queue considers it stale.
+     *
+     * @since 1.1.1
+     * @var int
+     */
+    private const STALE_PROCESSING_SECONDS = 7200;
+
+    /**
      * Get the singleton instance.
      *
      * @since 1.0.0
@@ -124,6 +132,18 @@ class Translation_Queue {
         $existing = $this->get_job($textdomain, $version, $locale);
 
         if ($existing) {
+            if ('failed' === $existing['status']) {
+                $this->reset_failed_job(
+                    (int) $existing['id'],
+                    $priority,
+                    $requested_by,
+                    $source_site,
+                    $plugin_source
+                );
+
+                return $existing['id'];
+            }
+
             // Update priority if higher.
             if ($priority > $existing['priority']) {
                 $wpdb->update(
@@ -340,6 +360,43 @@ class Translation_Queue {
     }
 
     /**
+     * Mark long-running processing jobs failed so they do not block slots.
+     *
+     * @since 1.1.1
+     * @param int $max_age_seconds Maximum processing age in seconds.
+     * @return int Number of jobs marked failed.
+     */
+    public function mark_stale_processing_jobs_failed( int $max_age_seconds = self::STALE_PROCESSING_SECONDS ): int {
+        global $wpdb;
+
+        $max_age_seconds = max( 300, $max_age_seconds );
+        $cutoff          = date( 'Y-m-d H:i:s', current_time( 'timestamp' ) - $max_age_seconds );
+        $completed_at    = current_time( 'mysql' );
+        $message         = sprintf(
+            'Job timed out after more than %d seconds in processing status and was marked failed automatically.',
+            $max_age_seconds
+        );
+
+        $result = $wpdb->query(
+            $wpdb->prepare(
+                "UPDATE {$this->table_name}
+                SET status = 'failed', completed_at = %s,
+                    error_message = CASE
+                        WHEN error_message IS NULL OR error_message = '' THEN %s
+                        ELSE error_message
+                    END
+                WHERE status = 'processing'
+                    AND (started_at IS NULL OR started_at < %s)",
+                $completed_at,
+                $message,
+                $cutoff
+            )
+        );
+
+        return false === $result ? 0 : (int) $result;
+    }
+
+    /**
      * Get count by status.
      *
      * @since 1.1.0
@@ -512,6 +569,8 @@ class Translation_Queue {
      * @return void
      */
     public function process_queue(): void {
+        $this->mark_stale_processing_jobs_failed();
+
         $slots_available = $this->get_available_slots();
 
         if ( $slots_available <= 0 ) {
@@ -616,6 +675,49 @@ class Translation_Queue {
             'started_at'    => null,
             'completed_at'  => null,
         ]);
+    }
+
+    /**
+     * Reset a failed job so a new API request can queue it again.
+     *
+     * @since 1.1.1
+     * @param int         $job_id        Job ID.
+     * @param int         $priority      Requested priority.
+     * @param string      $requested_by  Request source.
+     * @param string|null $source_site   Site URL that triggered the request.
+     * @param string      $plugin_source Plugin source.
+     * @return bool True on success.
+     */
+    private function reset_failed_job(
+        int $job_id,
+        int $priority,
+        string $requested_by,
+        ?string $source_site,
+        string $plugin_source
+    ): bool {
+        global $wpdb;
+
+        $result = $wpdb->update(
+            $this->table_name,
+            [
+                'status'            => 'requested',
+                'priority'          => max( 1, min( 10, $priority ) ),
+                'requested_by'      => $requested_by,
+                'source_site'       => $source_site,
+                'plugin_source'     => $plugin_source,
+                'started_at'        => null,
+                'completed_at'      => null,
+                'error_message'     => null,
+                'translated_count'  => 0,
+                'prompt_tokens'     => 0,
+                'completion_tokens' => 0,
+            ],
+            ['id' => $job_id],
+            ['%s', '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%d', '%d'],
+            ['%d']
+        );
+
+        return false !== $result;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Add a schema-versioned jobs-table updater so deployed installs receive queue columns used by current code.
- Auto-fail stale `processing` jobs before slot calculation so old jobs cannot permanently block the queue.
- Make new requests reset failed jobs and make `auto_approve` actually move requested jobs to pending.
- Suppress gp-openai-translate automation during both wp.org and fallback/local POT imports to avoid unrelated all-locale batch scheduling.

## Files changed

- `gratis-ai-translations-server.php`: schema version constant, runtime schema updater, shared install schema function.
- `src/class-translation-queue.php`: stale-processing cleanup, failed-job reset, queue slot protection.
- `src/class-rest-api.php`: `auto_approve` approval behavior for new and existing requested jobs.
- `src/class-translation-generator.php`: lossless automation hook suppression around source imports.

## Verification

- `php -l gratis-ai-translations-server.php`
- `php -l src/class-rest-api.php`
- `php -l src/class-translation-queue.php`
- `php -l src/class-translation-generator.php`
- `composer validate --no-check-publish`

## Production validation

- `wp gratis-ai-server status` runs without fatal errors.
- Public `translation-status` returns completed package for `superdav-ai-agent` `1.17.0` `es_ES`.
- Approved one requested `akismet` `5.7` `es_ES` job; it completed and produced a valid ZIP package.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.37 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
