### PR TITLE
fix: call Superdav v1 status endpoint

### DIFF
--- a/src/class-superdav-ai-client.php
+++ b/src/class-superdav-ai-client.php
@@ -276,8 +276,7 @@ class Superdav_AI_Client {
             );
         }
 
-        $base_url   = preg_replace( '#/v1/?$#', '', self::get_base_url() );
-        $status_url = trailingslashit( (string) $base_url ) . 'site/status';
+        $status_url = trailingslashit( self::get_base_url() ) . 'site/status';
 
         $response = wp_remote_get( $status_url, [
             'timeout' => 15,


### PR DESCRIPTION
## Summary

- Fix Superdav provider status checks to call the configured OpenAI-compatible `/v1/site/status` endpoint.
- Keep translation requests unchanged; they already call `/v1/chat/completions` through the configured base URL.

## Verification

- `php -l src/class-superdav-ai-client.php`
- Production symptom before fix: `wp gratis-ai-server status --check-provider` returned `Superdav AI Service status check returned HTTP 404` while translation requests succeeded.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.52 plugin for [OpenCode](https://opencode.ai) v1.17.13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the status check request path so it uses the app’s base URL consistently, helping ensure the connection status is checked against the correct endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->