### PR TITLE
fix: bound translation queue processing

### DIFF
--- a/src/class-cli.php
+++ b/src/class-cli.php
@@ -217,24 +217,30 @@ class CLI {
      * @return void
      */
     public function process(array $args, array $assoc_args): void {
-        $limit = (int) ($assoc_args['limit'] ?? 1);
+        $limit             = (int) ($assoc_args['limit'] ?? 1);
+        $processed_job_ids = [];
 
         for ($i = 0; $i < $limit; $i++) {
-            $job = $this->queue->get_next_pending_job();
+            $job = $this->queue->get_next_pending_job( $processed_job_ids );
 
             if (!$job) {
                 \WP_CLI::log($i === 0 ? 'No pending jobs to process.' : 'No more pending jobs.');
                 return;
             }
 
+            $processed_job_ids[] = (int) $job['id'];
+
             $target_type = $job['target_type'] ?? 'plugin';
             \WP_CLI::log("Processing job {$job['id']}: {$target_type} {$job['textdomain']} {$job['version']} ({$job['locale']})");
 
             $this->queue->update_job_status((int) $job['id'], 'processing');
             $result = $this->generator->generate_translation((int) $job['id']);
+            $updated_job = $this->queue->get_job_by_id( (int) $job['id'] );
 
-            if ($result) {
+            if ($result && $updated_job && 'completed' === $updated_job['status']) {
                 \WP_CLI::success("Job {$job['id']} completed successfully");
+            } elseif ($result && $updated_job && 'pending' === $updated_job['status']) {
+                \WP_CLI::success("Job {$job['id']} processed a chunk and was requeued");
             } else {
                 \WP_CLI::error("Job {$job['id']} failed", false);
             }

--- a/src/class-translation-generator.php
+++ b/src/class-translation-generator.php
@@ -159,14 +159,33 @@ class Translation_Generator {
                 ?: \GP_Locales::by_slug( $job['locale'] );
             $gp_locale = $locale_obj ? $locale_obj->slug : $job['locale'];
 
-            $batch_size       = (int) get_site_option( 'gratis_ai_ts_batch_size', 50 );
-            $batches          = array_chunk( $originals, $batch_size );
-            $total_translated = 0;
+            $batch_size                    = max( 1, (int) get_site_option( 'gratis_ai_ts_batch_size', 50 ) );
+            $batches                       = array_chunk( $originals, $batch_size );
+            $total_translated              = 0;
+            $translated_count_before_run   = max( 0, (int) ( $job['translated_count'] ?? 0 ) );
+            $prompt_tokens_before_run      = max( 0, (int) ( $job['prompt_tokens'] ?? 0 ) );
+            $completion_tokens_before_run  = max( 0, (int) ( $job['completion_tokens'] ?? 0 ) );
+            $total_string_count            = max(
+                count( $originals ),
+                (int) ( $job['string_count'] ?? 0 ),
+                count( $originals ) + $translated_count_before_run
+            );
+            $max_batches_per_run           = $this->get_max_batches_per_run();
+            $run_time_budget_seconds       = $this->get_run_time_budget_seconds();
+            $run_started_at                = microtime( true );
+            $batches_processed             = 0;
 
             // Reset token usage counter before starting this job's translations.
             $translator->reset_usage();
 
             foreach ( $batches as $batch ) {
+                if ( $batches_processed > 0
+                    && ( $batches_processed >= $max_batches_per_run
+                        || microtime( true ) - $run_started_at >= $run_time_budget_seconds )
+                ) {
+                    break;
+                }
+
                 $strings      = array_column( $batch, 'singular' );
                 $contexts     = array_column( $batch, 'context' );
                 $original_ids = array_column( $batch, 'id' );
@@ -201,13 +220,26 @@ class Translation_Generator {
                 // Map positional results back to originals by index.
                 $this->save_translations( $translation_set, $batch, $translated );
                 $total_translated += count( $translated );
+                $batches_processed++;
 
                 // Update progress with token usage so far.
-                $usage = $translator->get_accumulated_usage();
+                $usage                = $translator->get_accumulated_usage();
+                $current_translated   = $translated_count_before_run + $total_translated;
                 $queue->update_job_status( $job_id, 'processing', [
-                    'translated_count'  => $total_translated,
-                    'prompt_tokens'     => $usage['prompt_tokens'],
-                    'completion_tokens' => $usage['completion_tokens'],
+                    'string_count'      => $total_string_count,
+                    'translated_count'  => $current_translated,
+                    'prompt_tokens'     => $prompt_tokens_before_run + $usage['prompt_tokens'],
+                    'completion_tokens' => $completion_tokens_before_run + $usage['completion_tokens'],
+                ] );
+            }
+
+            if ( $total_translated < count( $originals ) ) {
+                $usage = $translator->get_accumulated_usage();
+                return $queue->requeue_partial_job( $job_id, [
+                    'string_count'      => $total_string_count,
+                    'translated_count'  => $translated_count_before_run + $total_translated,
+                    'prompt_tokens'     => $prompt_tokens_before_run + $usage['prompt_tokens'],
+                    'completion_tokens' => $completion_tokens_before_run + $usage['completion_tokens'],
                 ] );
             }
 
@@ -219,10 +251,10 @@ class Translation_Generator {
             $usage = $translator->get_accumulated_usage();
             $queue->update_job_status( $job_id, 'completed', [
                 'package_url'       => $zip_provider->get_zip_url(),
-                'string_count'      => count( $originals ),
-                'translated_count'  => $total_translated,
-                'prompt_tokens'     => $usage['prompt_tokens'],
-                'completion_tokens' => $usage['completion_tokens'],
+                'string_count'      => $total_string_count,
+                'translated_count'  => $translated_count_before_run + $total_translated,
+                'prompt_tokens'     => $prompt_tokens_before_run + $usage['prompt_tokens'],
+                'completion_tokens' => $completion_tokens_before_run + $usage['completion_tokens'],
             ] );
 
             return true;
@@ -1209,6 +1241,30 @@ class Translation_Generator {
         );
 
         return $wpdb->get_results( $sql );
+    }
+
+    /**
+     * Get the maximum number of provider batches a single queue run may process.
+     *
+     * @since 1.2.1
+     * @return int Maximum batches per queue run.
+     */
+    private function get_max_batches_per_run(): int {
+        $value = (int) get_site_option( 'gratis_ai_ts_max_batches_per_run', 2 );
+
+        return max( 1, min( 20, $value ) );
+    }
+
+    /**
+     * Get the soft runtime budget for one queue run.
+     *
+     * @since 1.2.1
+     * @return int Runtime budget in seconds.
+     */
+    private function get_run_time_budget_seconds(): int {
+        $value = (int) get_site_option( 'gratis_ai_ts_run_time_budget_seconds', 75 );
+
+        return max( 15, min( 300, $value ) );
     }
 
     /**

--- a/src/class-translation-queue.php
+++ b/src/class-translation-queue.php
@@ -555,14 +555,32 @@ class Translation_Queue {
      * Get next pending job.
      *
      * @since 1.0.0
+     * @param array $exclude_job_ids Job IDs to skip for this lookup.
      * @return array|null Job data or null.
      */
-    public function get_next_pending_job(): ?array {
+    public function get_next_pending_job(array $exclude_job_ids = []): ?array {
         global $wpdb;
+
+        $exclude_job_ids = array_values(
+            array_filter(
+                array_map(
+                    static function ( $job_id ): int {
+                        return max( 0, (int) $job_id );
+                    },
+                    $exclude_job_ids
+                )
+            )
+        );
+
+        $exclude_sql = '';
+        if ( ! empty( $exclude_job_ids ) ) {
+            $exclude_sql = 'AND id NOT IN (' . implode( ',', $exclude_job_ids ) . ')';
+        }
 
         $job = $wpdb->get_row(
             "SELECT * FROM {$this->table_name} 
             WHERE status = 'pending' 
+            {$exclude_sql}
             ORDER BY priority DESC, created_at ASC 
             LIMIT 1",
             ARRAY_A
@@ -586,12 +604,16 @@ class Translation_Queue {
             return;
         }
 
+        $processed_job_ids = [];
+
         for ($i = 0; $i < $slots_available; $i++) {
-            $job = $this->get_next_pending_job();
+            $job = $this->get_next_pending_job( $processed_job_ids );
 
             if (!$job) {
                 break;
             }
+
+            $processed_job_ids[] = (int) $job['id'];
 
             // Mark as processing.
             $this->update_job_status((int) $job['id'], 'processing');
@@ -615,6 +637,33 @@ class Translation_Queue {
      */
     private function process_job(int $job_id): void {
         Translation_Generator::instance()->generate_translation( $job_id );
+    }
+
+    /**
+     * Requeue a partially processed job for a later Action Scheduler run.
+     *
+     * @since 1.2.1
+     * @param int   $job_id Job ID.
+     * @param array $data   Progress data to persist while requeueing.
+     * @return bool True on success.
+     */
+    public function requeue_partial_job( int $job_id, array $data = [] ): bool {
+        $data = array_merge(
+            [
+                'started_at'    => null,
+                'completed_at'  => null,
+                'error_message' => null,
+            ],
+            $data
+        );
+
+        $updated = $this->update_job_status( $job_id, 'pending', $data );
+
+        if ( $updated && false === as_next_scheduled_action( 'gratis_ai_ts_process_queue', [], 'gratis_ai_ts' ) ) {
+            as_schedule_single_action( time() + MINUTE_IN_SECONDS, 'gratis_ai_ts_process_queue', [], 'gratis_ai_ts' );
+        }
+
+        return $updated;
     }
 
     /**


### PR DESCRIPTION
## Summary
- limit each translation queue run to bounded provider batches and a soft runtime budget
- requeue partially processed jobs as pending so Action Scheduler can resume safely
- prevent the same requeued job from being picked again within the same queue loop
- keep string, translated, and token progress cumulative across chunks

## Context
Large translation jobs on translate.ultimatemultisite.com can outlive the cron/Action Scheduler execution window. We observed job 257 remain in `processing` and AS action 189600 remain `in-progress` after the worker exited. Bounded chunks let later AS runs resume without holding one long process open.

## Verification
- `php -l src/class-translation-generator.php`
- `php -l src/class-translation-queue.php`
- `php -l src/class-cli.php`
- `composer validate --no-check-publish`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long-running translation jobs now continue in smaller chunks, with progress saved and resumed automatically.
  * Queue processing avoids picking the same job twice in one run.

* **Bug Fixes**
  * Improved job status reporting so completed and partially processed jobs are shown more accurately.
  * Translation progress and token usage now stay consistent across multiple runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->