### PR TITLE
fix: reuse glossary-aware translation prompts

### DIFF
--- a/gratis-ai-translations-server.php
+++ b/gratis-ai-translations-server.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gratis AI Translations Server
  * Plugin URI: https://translate.ultimatemultisite.com
  * Description: AI translation job queue for GlotPress. Manages translation requests, translates via Superdav AI Service or gp-openai-translate, and builds packages via Traduttore.
- * Version: 1.3.0
+ * Version: 1.3.1
  * Requires at least: 6.0
  * Requires PHP: 8.2
  * Author: Ultimate Multisite
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'GRATIS_AI_TS_VERSION', '1.3.0' );
+define( 'GRATIS_AI_TS_VERSION', '1.3.1' );
 define( 'GRATIS_AI_TS_SCHEMA_VERSION', '1.3.0' );
 define( 'GRATIS_AI_TS_FILE', __FILE__ );
 define( 'GRATIS_AI_TS_DIR', plugin_dir_path( __FILE__ ) );

--- a/gratis-ai-translations-server.php
+++ b/gratis-ai-translations-server.php
@@ -6,6 +6,7 @@
  * Version: 1.3.1
  * Requires at least: 6.0
  * Requires PHP: 8.2
+ * Requires Plugins: glotpress, gp-translate-with-openai
  * Author: Ultimate Multisite
  * Author URI: https://ultimatemultisite.com
  * License: GPL-2.0-or-later

--- a/src/class-superdav-ai-client.php
+++ b/src/class-superdav-ai-client.php
@@ -327,53 +327,12 @@ class Superdav_AI_Client {
             'model'           => self::get_model(),
             'temperature'     => self::get_temperature(),
             'response_format' => [ 'type' => 'json_object' ],
-            'messages'        => $this->build_glossary_aware_messages( $gp_locale, $strings, $contexts, $project_id ),
-        ];
-    }
-
-    /**
-     * Build chat messages using gp-openai-translate's glossary-aware prompt logic.
-     *
-     * The server owns the Superdav transport, credentials, and model selection, but
-     * prompt construction should stay aligned with gp-openai-translate so GlotPress
-     * glossary terms, locale instructions, and context handling remain consistent.
-     *
-     * @since 1.3.1
-     * @param string $gp_locale  GlotPress locale slug.
-     * @param array  $strings    Ordered source strings.
-     * @param array  $contexts   Ordered GlotPress contexts.
-     * @param int    $project_id GlotPress project ID.
-     * @return array<int,array{role:string,content:string}> OpenAI-compatible chat messages.
-     */
-    private function build_glossary_aware_messages( string $gp_locale, array $strings, array $contexts, int $project_id ): array {
-        if ( class_exists( '\\Meloniq\\GpOpenaiTranslate\\Translate' ) ) {
-            $translator = \Meloniq\GpOpenaiTranslate\Translate::instance();
-
-            if ( method_exists( $translator, 'build_batch_messages' ) ) {
-                return $translator->build_batch_messages( $strings, $gp_locale, $contexts, $project_id );
-            }
-        }
-
-        return [
-            [
-                'role'    => 'system',
-                'content' => implode( "\n", [
-                    'You translate WordPress plugin and theme strings.',
-                    'Return JSON only. Do not include Markdown or commentary.',
-                    'Return an object mapping numeric input indices to translations.',
-                    'Preserve placeholders, printf tokens, HTML tags, entities, whitespace significance, and GlotPress context meaning.',
-                ] ),
-            ],
-            [
-                'role'    => 'user',
-                'content' => implode( "\n", array_map(
-                    static function ( $string, $index ): string {
-                        return sprintf( '%d: %s', (int) $index, (string) $string );
-                    },
-                    array_values( $strings ),
-                    array_keys( array_values( $strings ) )
-                ) ),
-            ],
+            'messages'        => \Meloniq\GpOpenaiTranslate\Translate::instance()->build_batch_messages(
+                $strings,
+                $gp_locale,
+                $contexts,
+                $project_id
+            ),
         ];
     }
 

--- a/src/class-superdav-ai-client.php
+++ b/src/class-superdav-ai-client.php
@@ -321,39 +321,58 @@ class Superdav_AI_Client {
      * @return array<string,mixed>
      */
     private function build_chat_completion_payload( string $gp_locale, array $strings, array $contexts, array $original_ids, int $project_id ): array {
-        $items = [];
-
-        foreach ( array_values( $strings ) as $index => $string ) {
-            $items[] = [
-                'index'       => $index,
-                'original_id' => (int) ( $original_ids[ $index ] ?? 0 ),
-                'context'     => (string) ( $contexts[ $index ] ?? '' ),
-                'source'      => (string) $string,
-            ];
-        }
+        unset( $original_ids );
 
         return [
             'model'           => self::get_model(),
             'temperature'     => self::get_temperature(),
             'response_format' => [ 'type' => 'json_object' ],
-            'messages'        => [
-                [
-                    'role'    => 'system',
-                    'content' => implode( "\n", [
-                        'You translate WordPress plugin and theme strings.',
-                        'Return JSON only. Do not include Markdown or commentary.',
-                        'Return an object with a translations array in the same order as the input items.',
-                        'Preserve placeholders, printf tokens, HTML tags, entities, whitespace significance, and GlotPress context meaning.',
-                    ] ),
-                ],
-                [
-                    'role'    => 'user',
-                    'content' => wp_json_encode( [
-                        'locale'     => $gp_locale,
-                        'project_id' => $project_id,
-                        'items'      => $items,
-                    ] ),
-                ],
+            'messages'        => $this->build_glossary_aware_messages( $gp_locale, $strings, $contexts, $project_id ),
+        ];
+    }
+
+    /**
+     * Build chat messages using gp-openai-translate's glossary-aware prompt logic.
+     *
+     * The server owns the Superdav transport, credentials, and model selection, but
+     * prompt construction should stay aligned with gp-openai-translate so GlotPress
+     * glossary terms, locale instructions, and context handling remain consistent.
+     *
+     * @since 1.3.1
+     * @param string $gp_locale  GlotPress locale slug.
+     * @param array  $strings    Ordered source strings.
+     * @param array  $contexts   Ordered GlotPress contexts.
+     * @param int    $project_id GlotPress project ID.
+     * @return array<int,array{role:string,content:string}> OpenAI-compatible chat messages.
+     */
+    private function build_glossary_aware_messages( string $gp_locale, array $strings, array $contexts, int $project_id ): array {
+        if ( class_exists( '\\Meloniq\\GpOpenaiTranslate\\Translate' ) ) {
+            $translator = \Meloniq\GpOpenaiTranslate\Translate::instance();
+
+            if ( method_exists( $translator, 'build_batch_messages' ) ) {
+                return $translator->build_batch_messages( $strings, $gp_locale, $contexts, $project_id );
+            }
+        }
+
+        return [
+            [
+                'role'    => 'system',
+                'content' => implode( "\n", [
+                    'You translate WordPress plugin and theme strings.',
+                    'Return JSON only. Do not include Markdown or commentary.',
+                    'Return an object mapping numeric input indices to translations.',
+                    'Preserve placeholders, printf tokens, HTML tags, entities, whitespace significance, and GlotPress context meaning.',
+                ] ),
+            ],
+            [
+                'role'    => 'user',
+                'content' => implode( "\n", array_map(
+                    static function ( $string, $index ): string {
+                        return sprintf( '%d: %s', (int) $index, (string) $string );
+                    },
+                    array_values( $strings ),
+                    array_keys( array_values( $strings ) )
+                ) ),
             ],
         ];
     }


### PR DESCRIPTION
## Summary

- Reuse gp-openai-translate's glossary-aware batch prompt builder for Superdav translation requests.
- Keep Superdav-specific transport, credentials, model, temperature, response parsing, and token accounting in the translation server.
- Declare `gp-translate-with-openai` as a required plugin alongside GlotPress and call `Translate::build_batch_messages()` directly.
- Bump plugin version to `1.3.1`.

## Dependency

- Depends on Ultimate-Multisite/gp-translate-with-openai#5 for `Translate::build_batch_messages()`.

## Verification

- `php -l src/class-superdav-ai-client.php`
- `php -l gratis-ai-translations-server.php`
- `git diff --check`

## Context

Native Dutch review found that generated translations ignored glossary entries such as `website => site`, `login => login`, and `WordPress => WordPress`, and introduced brand-name hyphenation such as `WordPress-dashboard`. Investigation showed the Superdav path was reimplementing prompt construction instead of using gp-openai-translate's glossary-aware prompt logic.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.165 plugin for [OpenCode](https://opencode.ai) v1.18.4
